### PR TITLE
Fix examples link in README (#6)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    issuer (0.1.0)
+    issuer (0.2.0)
       faraday-retry (~> 2.0)
       octokit (~> 8.0)
       thor (~> 1.0)

--- a/README.adoc
+++ b/README.adoc
@@ -192,7 +192,7 @@ issues:
 ----
 
 [TIP]
-This repository contains numerous link:lib/examples/README.adoc[example files] to use for inspiration.
+This repository contains numerous link:examples/README.adoc[example files] to use for inspiration.
 
 The IMYML format will be standardized and formally specified in a future release of _issuer_, but it will remain an _open standard_ adoptable by anyone who wants to exploit or extend it.
 


### PR DESCRIPTION
## Summary

Fixes the broken link to examples documentation in the README.

## Changes

- Changed `lib/examples/README.adoc` to `examples/README.adoc`
- Updated Gemfile.lock to reflect version 0.2.0

## Testing

- All 64 RSpec tests pass
- CLI functionality tests pass
- YAML validation passes
- Documentation quality checks pass

## Issue

Closes #6